### PR TITLE
SP-13 Fix file to get yocto build working

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,4 +1,3 @@
 
-SRC_URI ="git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-
-firmware.git;protocol=https;branch=main"
+SRC_URI ="git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git;protocol=https;branch=main"
 


### PR DESCRIPTION
I found the following error when building yocto image.
```
ERROR: ParseError at /project/build-dir/../meta-adlink-x86-64bit/recipes-kernel/linux-firmware/linux-firmware_git.bbappend:2: unparsed line: 'SRC_URI ="git://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-'
```

I figure out that the error is related to syntax error `linux-firmware_git.bbappend` file.